### PR TITLE
Fixed .setFooter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,7 @@ new webcord({
     icon: "https://discord.com/assets/2c21aeda16de354ba5334551a883b481.png",
     url: "https://www.npmjs.com/package/webcord"
 }) // Sets an embed author
-.setFooter({
-    text: "I'm a footer",
-    icon: "https://discord.com/assets/e05ead6e6ebc08df9291738d0aa6986d.png"
-}) // Sets an embed footer
+.setFooter("I'm a footer", "https://discord.com/assets/e05ead6e6ebc08df9291738d0aa6986d.png") // Sets an embed footer
 .setURL("https://www.npmjs.com/package/webcord") // Adds a URL to the embeds title
 .setImage("https://discord.com/assets/fc0b01fe10a0b8c602fb0106d8189d9b.png") // Sets the image of the embed
 .setTimestamp() // Sets the timestamp of the embed

--- a/index.js
+++ b/index.js
@@ -219,16 +219,12 @@ class Webcord {
 	 * @param {?string} [options.icon] - Footer icon
 	 * @returns {Webcord} this
 	 */
-	setFooter(options = {
-		text: null,
-		icon: null
-	}) {
-		//if (!options) return err(new Error('You must include an object in .setFooter()'))
-		if (!options.text) return err(new Error('A `text` key must be specified in the object located inside .setFooter()'))
-		if (options.text.length > 2048) return err(new Error('The `text` key cannot be longer than 2048 characters located inside .setFooter()'))
+	setFooter(text, icon) {
+		if (!text) return err(new Error('A `text` key must be specified in the object located inside .setFooter()'))
+		if (text.length > 2048) return err(new Error('The `text` key cannot be longer than 2048 characters located inside .setFooter()'))
 		this.#footers[this.#embedIndex] = {
-			text: options.text,
-			icon_url: options.icon
+			text: text,
+			icon_url: icon
 		}
 		return this
 	}


### PR DESCRIPTION
- Fixed `setFooter` function to use correct syntax; Currently, you'd have to do `setFooter({text, icon})`, which isn't correct (According to docs - follows djs syntax). The syntax should be `setFooter(text, icon)`.